### PR TITLE
adapt brand package styles to NAU colors and font

### DIFF
--- a/paragon/_fonts.scss
+++ b/paragon/_fonts.scss
@@ -1,1 +1,2 @@
 // Add any font imports or definitions here
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');

--- a/paragon/_variables.scss
+++ b/paragon/_variables.scss
@@ -1,2 +1,16 @@
 // Use this file to set SASS variables for @edx/paragon
 // See _variables.scss in https://github.com/openedx/paragon/blob/master/scss/core/ for reference
+
+$primary: #074CC1 !default;
+$brand: #eec800 !default;
+$teal: $primary;
+
+// Fonts
+$font-family-sans-serif: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI",
+  "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji",
+  "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !default;
+
+// Button component overrides
+$btn-border-radius: 50rem !default;
+
+$custom-control-indicator-checked-color: $primary;


### PR DESCRIPTION
Add NAU colors and default _roboto font_ to the MFE Brand package

![image](https://github.com/fccn/brand-nau/assets/34194007/7b11a682-6bf4-407b-bf88-96199aa5195c)


closes https://github.com/fccn/nau-technical/issues/44